### PR TITLE
Added term query to posts endpoint

### DIFF
--- a/includes/class-rest-posts-controller.php
+++ b/includes/class-rest-posts-controller.php
@@ -268,7 +268,7 @@ class REST_Posts_Controller {
 				'description' => __( 'Parent post slug', 'fuxt-api' ),
 				'type'        => 'string',
 			),
-			'term_uri'        => array(
+			'term_slug'        => array(
 				'description' => __( 'Terms slug', 'fuxt-api' ),
 				'type'        => 'string',
 			),

--- a/includes/class-rest-posts-controller.php
+++ b/includes/class-rest-posts-controller.php
@@ -268,6 +268,10 @@ class REST_Posts_Controller {
 				'description' => __( 'Parent post slug', 'fuxt-api' ),
 				'type'        => 'string',
 			),
+			'term_uri'        => array(
+				'description' => __( 'Terms slug', 'fuxt-api' ),
+				'type'        => 'string',
+			),
 			'orderby'         => array(
 				'description' => __( 'orderby', 'fuxt-api' ),
 				'type'        => 'string',
@@ -338,10 +342,10 @@ class REST_Posts_Controller {
 		$posts             = PostUtils::get_posts( $request, $additional_fields );
 
 		if ( empty( $posts ) ) {
-			return new \WP_Error(
-				'rest_post_invalid_request',
-				__( 'Invalid request params.', 'fuxt-api' ),
-				array( 'status' => 404 )
+			$posts = array(
+				'list'        => array(),
+				'total'       => 0,
+				'total_pages' => 0,
 			);
 		}
 

--- a/includes/utils/class-post.php
+++ b/includes/utils/class-post.php
@@ -293,6 +293,33 @@ class Post {
 			}
 		}
 
+		if ( isset( $params['term_uri'] ) ) {
+			$terms = get_terms(
+				array(
+					'taxonomy' => get_taxonomies(),
+					'slug'     => $params['term_uri'],
+				)
+			);
+
+			if ( ! empty( $terms ) ) {
+				$query_params['tax_query'] = array(
+					array(
+						'taxonomy' => $terms[0]->taxonomy,
+						'field'    => 'slug',
+						'terms'    => $terms[0]->slug,
+					),
+				);
+
+				// Default order is menu_order for hierarchical post types such as page.
+				if ( is_post_type_hierarchical( $parent_post->post_type ) ) {
+					$query_params['orderby'] = 'menu_order';
+					$query_params['order']   = 'ASC';
+				}
+			} else {
+				return null;
+			}
+		}
+
 		if ( isset( $params['post_type'] ) ) {
 			$query_params['post_type'] = $params['post_type'];
 		} else {

--- a/includes/utils/class-post.php
+++ b/includes/utils/class-post.php
@@ -293,11 +293,11 @@ class Post {
 			}
 		}
 
-		if ( isset( $params['term_uri'] ) ) {
+		if ( isset( $params['term_slug'] ) ) {
 			$terms = get_terms(
 				array(
 					'taxonomy' => get_taxonomies(),
-					'slug'     => $params['term_uri'],
+					'slug'     => $params['term_slug'],
 				)
 			);
 


### PR DESCRIPTION
Added `term_uri` for term query by slug.
Example:
`/wp-json/fuxt/v1/posts?term_uri=genre1`