### PR TITLE
Fix block encoding

### DIFF
--- a/includes/utils/class-block.php
+++ b/includes/utils/class-block.php
@@ -193,6 +193,7 @@ class Block {
 		$css_selector = preg_replace( '/(\w+) \+ (\w+)/', '${1}/following-sibling::${2}[1]', $css_selector );
 		$css_selector = preg_replace( '/(\w+) \~ (\w+)/', '${1}/following-sibling::${2}', $css_selector );
 		$css_selector = str_replace( ' ', '//', $css_selector );
+		$css_selector = str_replace( ',', ' | //', $css_selector );
 
 		return '//' . $css_selector;
 	}

--- a/includes/utils/class-block.php
+++ b/includes/utils/class-block.php
@@ -208,7 +208,7 @@ class Block {
 		$dom = new \DOMDocument();
 
 		libxml_use_internal_errors( true );
-		$dom->loadHTML( sprintf( '<body>%s</body>', trim( $html ) ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+		$dom->loadHTML( sprintf( '<meta http-equiv="Content-Type" content="charset=utf-8"/><body>%s</body>', trim( $html ) ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 		libxml_clear_errors();
 
 		return $dom;
@@ -222,11 +222,7 @@ class Block {
 	 * @return string
 	 */
 	private static function get_inner_html( $html ) {
-		$dom = new \DOMDocument();
-
-		libxml_use_internal_errors( true );
-		$dom->loadHTML( sprintf( '<body>%s</body>', trim( $html ) ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
-		libxml_clear_errors();
+		$dom = self::get_dom_document( $html );
 
 		$body_node   = $dom->getElementsByTagName( 'body' )->item( 0 );
 		$first_child = $body_node ? $body_node->firstChild : $dom->documentElement->firstChild;


### PR DESCRIPTION
- Fixed issue with UTF8 character code in block content parsing
- Fixed issue with DOM multi-selector (for example `h1,h2,h3`)