### PR TITLE
Fix post order

### DIFF
--- a/includes/utils/class-post.php
+++ b/includes/utils/class-post.php
@@ -237,7 +237,6 @@ class Post {
 		$post_type = get_post_type( $post );
 
 		$orderby = $post_type === 'post' ? 'date' : 'menu_order';
-		$order   = $post_type === 'post' ? 'DESC' : 'ASC';
 		// Get all siblings pages
 		// Yes this isn't effienct to query all pages,
 		// but actually it works well for thousands of pages in practice.
@@ -245,7 +244,7 @@ class Post {
 			'post_type'      => get_post_type( $post ),
 			'posts_per_page' => -1,
 			'orderby'        => $orderby,
-			'order'          => $order,
+			'order'          => 'ASC',
 			'post_parent'    => $post->post_parent,
 		);
 

--- a/includes/utils/class-post.php
+++ b/includes/utils/class-post.php
@@ -241,7 +241,7 @@ class Post {
 		// Yes this isn't effienct to query all pages,
 		// but actually it works well for thousands of pages in practice.
 		$args = array(
-			'post_type'      => get_post_type( $post ),
+			'post_type'      => $post_type,
 			'posts_per_page' => -1,
 			'orderby'        => $orderby,
 			'order'          => 'ASC',

--- a/includes/utils/class-post.php
+++ b/includes/utils/class-post.php
@@ -234,14 +234,18 @@ class Post {
 	 * @return \WP_Post[]
 	 */
 	public static function get_sibling_posts( $post ) {
+		$post_type = get_post_type( $post );
+
+		$orderby = $post_type === 'post' ? 'date' : 'menu_order';
+		$order   = $post_type === 'post' ? 'DESC' : 'ASC';
 		// Get all siblings pages
-		// Yes this is isn't effienct to query all pages,
+		// Yes this isn't effienct to query all pages,
 		// but actually it works well for thousands of pages in practice.
 		$args = array(
 			'post_type'      => get_post_type( $post ),
 			'posts_per_page' => -1,
-			'orderby'        => 'menu_order',
-			'order'          => 'ASC',
+			'orderby'        => $orderby,
+			'order'          => $order,
 			'post_parent'    => $post->post_parent,
 		);
 


### PR DESCRIPTION
For siblings order, use `date` for blog post by default