### PR TITLE
Fix warnings

### DIFF
--- a/includes/class-rest-acf-controller.php
+++ b/includes/class-rest-acf-controller.php
@@ -48,9 +48,10 @@ class REST_Acf_Controller {
 
 	public function get_item_schema() {
 		$schema = array(
-			'$schema' => 'http://json-schema.org/draft-04/schema#',
-			'title'   => 'fuxt_acf_options',
-			'type'    => 'object',
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'fuxt_acf_options',
+			'type'       => 'object',
+			'properties' => array(),
 		);
 
 		return $schema;

--- a/includes/class-rest-acf-controller.php
+++ b/includes/class-rest-acf-controller.php
@@ -80,6 +80,7 @@ class REST_Acf_Controller {
 			'name' => array(
 				'description' => __( 'ACF option name', 'fuxt-api' ),
 				'type'        => 'string',
+				'required'    => true,
 			),
 		);
 	}

--- a/includes/class-rest-post-controller.php
+++ b/includes/class-rest-post-controller.php
@@ -138,6 +138,10 @@ class REST_Post_Controller {
 					'description' => __( 'The excerpt for the post.' ),
 					'type'        => 'string',
 				),
+				'raw_excerpt'        => array(
+					'description' => __( 'The raw excerpt data for the post. Returns empty strying if field data is empty.' ),
+					'type'        => 'string',
+				),
 				'featured_media' => array(
 					'description' => __( 'Featured media for the post.' ),
 					'type'        => array( 'object', 'null' ),

--- a/includes/class-rest-post-controller.php
+++ b/includes/class-rest-post-controller.php
@@ -138,7 +138,7 @@ class REST_Post_Controller {
 					'description' => __( 'The excerpt for the post.' ),
 					'type'        => 'string',
 				),
-				'raw_excerpt'        => array(
+				'excerpt_raw'        => array(
 					'description' => __( 'The raw excerpt data for the post. Returns empty strying if field data is empty.' ),
 					'type'        => 'string',
 				),

--- a/includes/libs/class-wp-github-updater.php
+++ b/includes/libs/class-wp-github-updater.php
@@ -362,7 +362,7 @@ class WP_GitHub_Updater {
 	 */
 	public function get_plugin_data() {
 		include_once ABSPATH . '/wp-admin/includes/plugin.php';
-		$data = get_plugin_data( WP_PLUGIN_DIR . '/' . $this->config['slug'] );
+		$data = get_plugin_data( WP_PLUGIN_DIR . '/' . $this->config['slug'], false, false );
 		return $data;
 	}
 

--- a/includes/utils/class-post.php
+++ b/includes/utils/class-post.php
@@ -46,7 +46,7 @@ class Post {
 			'title'          => get_the_title( $post ),
 			'content'        => apply_filters( 'the_content', $post->post_content ),
 			'excerpt'        => apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $post->post_excerpt, $post ) ),
-			'excerpt_raw'    => $post->post_excerpt,
+			'excerpt_raw'    => apply_filters( 'the_excerpt', $post->post_excerpt ),
 			'slug'           => $post->post_name,
 			'url'            => $url,
 			'uri'            => $to,

--- a/includes/utils/class-post.php
+++ b/includes/utils/class-post.php
@@ -46,6 +46,7 @@ class Post {
 			'title'          => get_the_title( $post ),
 			'content'        => apply_filters( 'the_content', $post->post_content ),
 			'excerpt'        => apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $post->post_excerpt, $post ) ),
+			'raw_excerpt'    => $post->post_excerpt,
 			'slug'           => $post->post_name,
 			'url'            => $url,
 			'uri'            => $to,

--- a/includes/utils/class-post.php
+++ b/includes/utils/class-post.php
@@ -46,7 +46,7 @@ class Post {
 			'title'          => get_the_title( $post ),
 			'content'        => apply_filters( 'the_content', $post->post_content ),
 			'excerpt'        => apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $post->post_excerpt, $post ) ),
-			'raw_excerpt'    => $post->post_excerpt,
+			'excerpt_raw'    => $post->post_excerpt,
 			'slug'           => $post->post_name,
 			'url'            => $url,
 			'uri'            => $to,


### PR DESCRIPTION
- Fixed Open API schema issue which causes Open API page(wp-admin/admin.php?page=wp-openapi) broken.
- Fixed translate domain `fuxt-api` loaded too early warning.