### PR TITLE
Add ACF fields support for menu items

### DIFF
--- a/includes/class-rest-menu-controller.php
+++ b/includes/class-rest-menu-controller.php
@@ -122,6 +122,10 @@ class REST_Menu_Controller {
 							'type' => 'object',
 						),
 					),
+					'acf'         => array(
+						'description' => __( 'ACF custom fields for this menu item.', 'fuxt-api' ),
+						'type'        => array( 'object', 'null' ),
+					),
 				),
 			),
 		);
@@ -237,6 +241,14 @@ class REST_Menu_Controller {
 		}
 
 		$menu_data['children'] = array();
+
+		// Add ACF fields if available
+		if ( function_exists( 'get_fields' ) ) {
+			$acf_fields = get_fields( $menu_item->ID );
+			if ( $acf_fields ) {
+				$menu_data['acf'] = $acf_fields;
+			}
+		}
 
 		return $menu_data;
 	}


### PR DESCRIPTION
Closes #108

## What this does

Adds support for ACF custom fields on menu items. If a menu item has ACF fields attached to it, they'll now be included in the REST API response under an `acf` property.

## Changes

- Added `acf` property to the schema in `get_item_schema()`
- Modified `get_menu_data()` to fetch and include ACF fields when available

## How it works

The code checks if ACF is installed (`function_exists('get_fields')`) before trying to get fields, so it won't break anything on sites without ACF. If there are no ACF fields on a menu item, the `acf` property simply won't be included in the response.

## Example response

Before:
```json
{
  "id": 123,
  "title": "My Menu Item",
  "url": "https://example.com"
}
```

After (with ACF fields):
```json
{
  "id": 123,
  "title": "My Menu Item",
  "url": "https://example.com",
  "acf": {
    "logo": {
      "url": "https://example.com/logo.svg"
    }
  }
}
```

Pretty straightforward change, lmk if you have any questions or want me to adjust anything!