### PR TITLE
Allow pending posts to be previewed like drafts

### DIFF
--- a/includes/class-rest-post-controller.php
+++ b/includes/class-rest-post-controller.php
@@ -513,7 +513,7 @@ class REST_Post_Controller {
 			return true;
 		}
 
-		if ( 'draft' === $post->post_status ) {
+		if ( in_array( $post->post_status, array( 'draft', 'pending' ), true ) ) {
 			$user_id = apply_filters( 'determine_current_user', false );
 			if ( ! empty( $user_id ) ) {
 				return PostUtils::can_user_read_post( $user_id, $post->ID );

--- a/includes/utils/class-post.php
+++ b/includes/utils/class-post.php
@@ -520,7 +520,7 @@ class Post {
 					}
 
 					$post_status_obj = get_post_status_object( $page->post_status );
-					if ( $page->post_status !== 'draft' && ! $post_status_obj->public && ! $post_status_obj->protected
+					if ( $page->post_status !== 'draft' && $page->post_status !== 'pending' && ! $post_status_obj->public && ! $post_status_obj->protected
 						&& ! $post_status_obj->private && $post_status_obj->exclude_from_search ) {
 						continue;
 					}
@@ -555,6 +555,7 @@ class Post {
 				$query['post_status'] = array(
 					'publish',
 					'draft',
+					'pending',
 				);
 
 				// Do the query.

--- a/includes/utils/class-post.php
+++ b/includes/utils/class-post.php
@@ -316,13 +316,13 @@ class Post {
 			return false;
 		}
 
-		// Check if the post exists and is a draft
-		if ( $post->post_status === 'draft' ) {
-			// Check if the user is the author of the post or have permission.
+		// Draft and pending posts are previewable by their author, or by users
+		// who can read private posts (editors/admins).
+		if ( in_array( $post->post_status, array( 'draft', 'pending' ), true ) ) {
 			return $post->post_author === $user_id || user_can( $user_id, 'read_private_posts' );
 		}
 
-		// Post is not a draft or doesn't exist
+		// Otherwise, only published posts are readable.
 		return $post->post_status === 'publish';
 	}
 


### PR DESCRIPTION
## Problem
Preview of **pending** posts was denied on the headless frontend, while drafts worked. Three places special-cased `draft` but never `pending`:

- `Utils\Post::url_to_postid()` — the URI-to-post resolver limited its `WP_Query` to `publish` + `draft`, so a pending post was never *found* by URI (the `/post` endpoint 404'd before any read check). Same draft-only assumption in the verbose-page-rule branch.
- `REST_Post_Controller::check_read_permission()` — the `draft`-only branch that re-derives the user (enabling cookie-based preview without a REST nonce) never ran for pending.
- `Utils\Post::can_user_read_post()` — only handled `draft` and `publish`.

## Fix
Treat `pending` the same as `draft` in all three. Authors can preview their own pending posts; editors/admins via `read_private_posts`.

Base bug — affects any fuxt site using a submit-for-review flow. Verified on staging: resolution and both read checks pass for a pending CPT post.
