### PR TITLE
Fuxt API - Yoast SEO Field

### DIFF
--- a/includes/class-rest-post-controller.php
+++ b/includes/class-rest-post-controller.php
@@ -85,6 +85,7 @@ class REST_Post_Controller {
 						'ancestors',
 						'next',
 						'prev',
+						'seo',
 					),
 				),
 			),
@@ -328,6 +329,10 @@ class REST_Post_Controller {
 					'description' => __( '(Optional by request) Previous data.' ),
 					'type'        => array( 'object', 'null' ),
 				),
+				'seo'            => array(
+					'description' => __( '(Optional by request) Yoast SEO meta data. Null when the Yoast SEO plugin is not active. The `schema` property is a JSON-LD string.' ),
+					'type'        => array( 'object', 'null' ),
+				),
 			),
 		);
 
@@ -442,6 +447,7 @@ class REST_Post_Controller {
 			'next',
 			'prev',
 			'depth',
+			'seo',
 		);
 
 		// Trim off outside whitespace from the comma delimited list.

--- a/includes/class-rest-posts-controller.php
+++ b/includes/class-rest-posts-controller.php
@@ -141,6 +141,7 @@ class REST_Posts_Controller {
 						'ancestors',
 						'next',
 						'prev',
+						'seo',
 					),
 				),
 			),
@@ -223,6 +224,7 @@ class REST_Posts_Controller {
 			'ancestors',
 			'next',
 			'prev',
+			'seo',
 		);
 
 		// Trim off outside whitespace from the comma delimited list.

--- a/includes/utils/class-post.php
+++ b/includes/utils/class-post.php
@@ -72,6 +72,10 @@ class Post {
 				}
 			}
 
+			if ( in_array( 'seo', $additional_fields ) ) {
+				$data['seo'] = self::get_seodata( $post );
+			}
+
 			// Inherit additional fields for siblings, parent, children, next, prev post.
 			$inherit_fields = array_intersect(
 				$additional_fields,
@@ -204,6 +208,44 @@ class Post {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Get Yoast SEO meta data for a post.
+	 *
+	 * Uses the Yoast SEO surface API. Returns null when Yoast SEO is not active
+	 * or has no meta for the post.
+	 *
+	 * @param \WP_Post $post Post object.
+	 *
+	 * @return array|null
+	 */
+	private static function get_seodata( $post ) {
+		if ( ! function_exists( 'YoastSEO' ) ) {
+			return null;
+		}
+
+		$meta = YoastSEO()->meta->for_post( $post->ID );
+
+		if ( ! $meta ) {
+			return null;
+		}
+
+		$json = json_decode( wp_json_encode( $meta->get_head()->json ), true );
+
+		if ( ! is_array( $json ) ) {
+			return null;
+		}
+
+		// Ship schema as a JSON string so JSON-LD keys (@context, @graph) survive client-side key transforms.
+		if ( isset( $json['schema'] ) ) {
+			$json['schema'] = wp_json_encode( $json['schema'] );
+		}
+
+		// Keyed by human-readable labels, which key transforms would mangle.
+		unset( $json['twitter_misc'] );
+
+		return $json;
 	}
 
 	/**


### PR DESCRIPTION
## What

Adds an optional `seo` value to the `fields` param on the `/fuxt/v1/post` and `/fuxt/v1/posts` endpoints. When requested (e.g. `?uri=/home/&fields=acf,seo`), the response includes the full Yoast SEO meta payload for the post — title, description, robots, canonical, all Open Graph and Twitter tags, article timestamps, and the complete JSON-LD schema graph.

## Why

Our fuxt endpoints build responses with custom callbacks rather than WP core REST controllers, so Yoast's automatic `yoast_head_json` field never appears on them. This exposes the same data through the existing `fields` pattern, letting headless frontends render full SEO head tags from the single page fetch they already make.

## How

- `Post::get_postdata()` gains a `seo` block that calls Yoast's surface API: `YoastSEO()->meta->for_post( $id )->get_head()->json`
- Guarded by `function_exists( 'YoastSEO' )` — returns `seo: null` when Yoast isn't active, so this is safe on sites without the plugin
- `seo` is **not** inherited by `children`/`siblings`/`next`/`prev` sub-posts, to keep list responses lean
- Registered in the `fields` enum, allowed-fields list, and item schema on both controllers

Two payload adjustments for headless clients that camelCase response keys:
- `schema` is shipped as a JSON **string** (not an object) so JSON-LD keys like `@context`/`@graph` survive client-side key transforms — inject it directly into a `<script type="application/ld+json">` tag
- `twitter_misc` is dropped (keyed by human-readable labels, which key transforms would mangle)

## Frontend reference

The corresponding Nuxt consumption pattern lives on the **freshman-year** frontend's `yoast-seo` branch: a prop-driven `wp-seo.vue` that maps the camelCased `seo` object to `useSeoMeta`/`useHead` (with site-settings fallbacks), pages adding `seo` to their `fields` param, and a titleTemplate guard since Yoast titles already include the site name. Use that as the template when rolling this out to other fuxt sites.