### PR TITLE
Adds yoast

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -24,6 +24,7 @@ class Plugin extends Plugin_Base {
 		( new REST_Acf_Controller() )->init();
 		( new REST_Posts_Controller() )->init();
 		( new REST_User_Controller() )->init();
+		( new Yoast_Seo() )->init();
 
 		$this->update_check();
 	}

--- a/includes/class-yoast-seo.php
+++ b/includes/class-yoast-seo.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Class Yoast_Seo
+ *
+ * @package FuxtApi
+ */
+
+namespace FuxtApi;
+
+/**
+ * Class Yoast_Seo
+ *
+ * Adds Yoast's `yoast_head_json` to the fuxt `/post` response so the frontend
+ * can fetch SEO data in a single request. Fails gracefully when the Yoast SEO
+ * plugin is not active: no field is added and the response is left untouched.
+ *
+ * @package FuxtApi
+ */
+class Yoast_Seo {
+
+	/**
+	 * Init function.
+	 */
+	public function init() {
+		add_filter( 'rest_post_dispatch', array( $this, 'add_yoast_head' ), 10, 3 );
+	}
+
+	/**
+	 * Add yoast_head_json to the fuxt /post response.
+	 *
+	 * @param mixed $result WP_REST_Response or WP_Error.
+	 * @param WP_REST_Server $server REST server instance.
+	 * @param WP_REST_Request $request Current request.
+	 * @return mixed
+	 */
+	public function add_yoast_head( $result, $server, $request ) {
+		if ( $request->get_route() !== '/fuxt/v1/post' ) {
+			return $result;
+		}
+
+		if ( is_wp_error( $result ) || ! ( $result instanceof \WP_REST_Response ) ) {
+			return $result;
+		}
+
+		$data = $result->get_data();
+
+		if ( ! is_array( $data ) || empty( $data['id'] ) ) {
+			return $result;
+		}
+
+		$data['yoast_head_json'] = $this->get_yoast_head_json( (int) $data['id'] );
+
+		$result->set_data( $data );
+
+		return $result;
+	}
+
+	/**
+	 * Fetch Yoast's yoast_head_json for a post.
+	 *
+	 * Uses Yoast's own REST field via an in-process request, so the shape always
+	 * matches what WP REST returns and no extra HTTP round-trip is made.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array|null Yoast head data, or null when unavailable.
+	 */
+	private function get_yoast_head_json( $post_id ) {
+		if ( ! function_exists( 'YoastSEO' ) ) {
+			return null;
+		}
+
+		$post = get_post( $post_id );
+
+		if ( ! $post ) {
+			return null;
+		}
+
+		$post_type_object = get_post_type_object( $post->post_type );
+
+		if ( empty( $post_type_object ) ) {
+			return null;
+		}
+
+		$rest_base = ! empty( $post_type_object->rest_base )
+			? $post_type_object->rest_base
+			: $post_type_object->name;
+
+		$request = new \WP_REST_Request(
+			'GET',
+			sprintf( '/wp/v2/%s/%d', $rest_base, $post_id )
+		);
+		$request->set_query_params( array( '_fields' => 'yoast_head_json' ) );
+
+		$response = rest_do_request( $request );
+
+		if ( $response->is_error() ) {
+			return null;
+		}
+
+		$data = $response->get_data();
+
+		return ( is_array( $data ) && isset( $data['yoast_head_json'] ) )
+			? $data['yoast_head_json']
+			: null;
+	}
+}


### PR DESCRIPTION
# fuxt ↔ Yoast SEO — what changed and how it works now

Yoast's `yoast_head_json` is added to the fuxt `/post` response by a small class
inside the fuxt-api plugin, and the Nuxt frontend consumes it in a single request.

---

## Architecture

```
Nuxt frontend (app/plugins/yoast.ts)
   │  GET /wp-json/fuxt/v1/post?uri=<path>   (one request)
   ▼
fuxt-api  REST_Post_Controller  →  builds the post object
   │
   ▼  (response passes through rest_post_dispatch)
Yoast_Seo  (includes/class-yoast-seo.php)
   │  matches /fuxt/v1/post, adds `yoast_head_json`
   ▼
response with `yoast_head_json` inline
```

---

## Backend — `includes/class-yoast-seo.php`

A single class, `Yoast_Seo`, in the `FuxtApi` namespace. It's loaded from
`class-plugin.php`:

```php
( new Yoast_Seo() )->init();
```

(The autoloader maps `Yoast_Seo` → `includes/class-yoast-seo.php` — no `require`.)

**1. The hook** — `add_yoast_head()` on `rest_post_dispatch`:

```php
public function init() {
    add_filter( 'rest_post_dispatch', array( $this, 'add_yoast_head' ), 10, 3 );
}

public function add_yoast_head( $result, $server, $request ) {
    if ( $request->get_route() !== '/fuxt/v1/post' ) {
        return $result;                         // only the fuxt post endpoint
    }

    if ( is_wp_error( $result ) || ! ( $result instanceof \WP_REST_Response ) ) {
        return $result;
    }

    $data = $result->get_data();
    if ( ! is_array( $data ) || empty( $data['id'] ) ) {
        return $result;
    }

    $data['yoast_head_json'] = $this->get_yoast_head_json( (int) $data['id'] );
    $result->set_data( $data );

    return $result;
}
```

**2. The fetch** — `get_yoast_head_json()`:

```php
private function get_yoast_head_json( $post_id ) {
    if ( ! function_exists( 'YoastSEO' ) ) {
        return null;                            // ← graceful: Yoast not active
    }

    $post = get_post( $post_id );
    if ( ! $post ) {
        return null;
    }

    $post_type_object = get_post_type_object( $post->post_type );
    if ( empty( $post_type_object ) ) {
        return null;
    }

    $rest_base = ! empty( $post_type_object->rest_base )
        ? $post_type_object->rest_base
        : $post_type_object->name;

    $request = new \WP_REST_Request( 'GET', sprintf( '/wp/v2/%s/%d', $rest_base, $post_id ) );
    $request->set_query_params( array( '_fields' => 'yoast_head_json' ) );

    $response = rest_do_request( $request );    // in-process, no extra HTTP hop

    if ( $response->is_error() ) {
        return null;
    }

    $data = $response->get_data();

    return ( is_array( $data ) && isset( $data['yoast_head_json'] ) )
        ? $data['yoast_head_json']
        : null;
}
```

Notes:

- `rest_do_request()` reuses Yoast's own REST field (`yoast_head_json`, which
  Yoast registers on every `show_in_rest` post type) **in-process** — no extra
  HTTP round-trip, and the shape always matches what WP REST would return.
- `rest_base` comes from `$post_type_object->rest_base`, which WordPress computes
  at registration time — so `page → pages`, `post → posts`, and any custom post
  type are handled automatically.
- **Graceful failure**: every guard returns `null` rather than throwing. With
  Yoast inactive, `yoast_head_json` is simply `null` and the frontend falls back
  to site settings.

---

## Frontend — `app/plugins/yoast.ts` (unchanged)

The frontend already does a single request and reads the inline field:

```ts
const entity = await $fetch<{ id?: number; type?: string; yoast_head_json?: YoastHeadJson } | null>(
    `${wordpressApiUrl}/post`,
    { query: { uri: path }, timeout: WP_TIMEOUT_MS }
)

if (entity?.yoast_head_json) {
    resolved.head = entity.yoast_head_json
    resolved.entityType = entity.type || ''
}
```

…and `useHead` maps it onto `<title>`, meta description, robots, Open Graph,
Twitter card, canonical, and the JSON-LD schema. Routes with no WP entity fall
back to site settings.

---

## Request / response shape

```
GET /wp-json/fuxt/v1/post?uri=<route.path>
```

```jsonc
{
  "id": 106,
  "type": "page",
  "title": "About",
  "uri": "/about/",
  // ...existing fuxt fields...
  "yoast_head_json": {
    "title": "…",
    "description": "…",
    "robots": { "index": "index", "follow": "follow" },
    "canonical": "https://…/about/",
    "og_locale": "en_US",
    "og_type": "article",
    "og_title": "…",
    "og_description": "…",
    "og_url": "https://…/about/",
    "og_site_name": "RIOS",
    "og_image": [{ "url": "…", "width": 2500, "height": 1667, "type": "image/jpeg" }],
    "twitter_card": "summary_large_image",
    "twitter_title": "…",
    "twitter_description": "…",
    "article_modified_time": "…",
    "schema": { "@context": "https://schema.org", "@graph": [ … ] }
  }
}
```

---

## Verification

```bash
# backend returns the field:
curl -s "https://<site>/wp-json/fuxt/v1/post?uri=/about/" | jq '.yoast_head_json'

# frontend (once deployed):
curl -s "https://<frontend>/about/" | grep -oE 'property="og:[^"]*"|rel="canonical"|application/ld\+json'
```

## Deploy order

1. Ship the fuxt-api change (new class + the `class-plugin.php` line).
2. Frontend is already single-request; no frontend change required.

If the frontend runs before the backend, `entity.yoast_head_json` is simply
absent and the plugin falls back to site settings — no breakage.
